### PR TITLE
add another notification type for test in pull request

### DIFF
--- a/.github/examples/run_tests.yaml
+++ b/.github/examples/run_tests.yaml
@@ -8,12 +8,17 @@ on:
       - "*"
 
 jobs:
-  notification:
-    uses: kaltura/ovp-pipelines-pub/.github/workflows/notification.yaml@master
-    secrets:
-      PLAYER_MSTEAMS_WEBHOOK: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
   running-tests:
     uses: kaltura/ovp-pipelines-pub/.github/workflows/player_tests.yaml@master
     with:
       yarn-run-to-execute: 'eslint flow test'
-
+  notification:
+    if: always()
+    uses: kaltura/ovp-pipelines-pub/.github/workflows/notification.yaml@master
+    needs: running-tests
+    secrets:
+      PLAYER_MSTEAMS_WEBHOOK: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
+    with:
+      failure-status: ${{ contains(needs.*.result, 'failure') }}
+      cancelled-status: ${{ contains(needs.*.result, 'cancelled') }}
+      is-test: 'true'

--- a/.github/workflows/notification.yaml
+++ b/.github/workflows/notification.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: 'false'
+      is-test:
+        description: "is test or not - example: 'true/false'"
+        required: false
+        type: string
+        default: 'false'
 
 jobs:
   notification:
@@ -43,7 +48,6 @@ jobs:
           echo $status
           echo "status=${status}" >> $GITHUB_OUTPUT
       - name: Set image status url
-        if: always()
         id: image_url
         run: |
           if ${{ inputs.failure-status }} || ${{ inputs.cancelled-status }}; then
@@ -72,7 +76,7 @@ jobs:
           echo "inputs=${inputs}" >> $GITHUB_OUTPUT
       - name: Microsoft Teams Notification pull_request
         uses: skitionek/notify-microsoft-teams@v1.0.4
-        if: (always()) && (github.event_name == 'pull_request')
+        if: (always()) && (github.event_name == 'pull_request') && (${{ inputs.is-test }} != 'true')
         with:
           webhook_url: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
           raw: >-
@@ -170,6 +174,45 @@ jobs:
                 }, {
                   "name": "Workflow link",
                   "value": "https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}/actions/runs/${{ github.run_id }}"
+                } ],
+                "markdown": true
+              } ]
+            }
+      - name: Microsoft Teams Notification Tests
+        uses: skitionek/notify-microsoft-teams@v1.0.4
+        if: (always()) && (github.event_name == 'pull_request') && (inputs.is-test == 'true')
+        with:
+          webhook_url: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
+          raw: >-
+            {
+              "@type": "MessageCard",
+              "@context": "http://schema.org/extensions",
+              "summary": "Player Workflow",
+              "sections": [ {
+                "activityTitle": "Running tests on ${{ github.event.repository.name }}",
+                "activitySubtitle": "Assigned to: ${{ github.actor }}",
+                "activityImage": "${{ steps.image_url.outputs.image_url }}",
+                "facts": [ {
+                  "name": "Status",
+                  "value": "${{ steps.status.outputs.status }}"
+                }, {
+                  "name": "From branch",
+                  "value": "${{ github.head_ref }}"
+                }, {
+                  "name": "To branch",
+                  "value": "${{ github.base_ref }}"
+                }, {
+                  "name": "Commit ID",
+                  "value": "${{ github.sha }}"
+                }, {
+                  "name": "Pull request number",
+                  "value": "${{ github.event.number }}"
+                }, {
+                  "name": "Pull request title",
+                  "value": "${{ github.event.pull_request.title }}"
+                }, {
+                  "name": "Pull request link",
+                  "value": "${{ github.event.pull_request._links.html.href }}"
                 } ],
                 "markdown": true
               } ]


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
