### PR TITLE
add another notification type for test in pull request

### DIFF
--- a/.github/workflows/player_tests.yaml
+++ b/.github/workflows/player_tests.yaml
@@ -3,6 +3,9 @@ run-name: Player And Plugin Tests
 
 on:
   workflow_call:
+    secrets:
+      PLAYER_MSTEAMS_WEBHOOK:
+        required: true
     inputs:
       yarn-upgrade-list:
         description: "list of packages to overwrite in package.json - example: 'playkit-js/playkit-js@canary @playkit-js/playkit-js-dash@canary'"
@@ -81,3 +84,13 @@ jobs:
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
 
+  notification:
+    if: always()
+    uses: ./.github/workflows/notification.yaml
+    needs: [set-matrix, running-tests]
+    secrets:
+      PLAYER_MSTEAMS_WEBHOOK: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
+    with:
+      failure-status: ${{ contains(needs.*.result, 'failure') }}
+      cancelled-status: ${{ contains(needs.*.result, 'cancelled') }}
+      is-test: 'true'


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
- test notification
