### PR TITLE
add another notification type for test in pull request

### DIFF
--- a/.github/examples/run_tests.yaml
+++ b/.github/examples/run_tests.yaml
@@ -12,13 +12,3 @@ jobs:
     uses: kaltura/ovp-pipelines-pub/.github/workflows/player_tests.yaml@master
     with:
       yarn-run-to-execute: 'eslint flow test'
-  notification:
-    if: always()
-    uses: kaltura/ovp-pipelines-pub/.github/workflows/notification.yaml@master
-    needs: running-tests
-    secrets:
-      PLAYER_MSTEAMS_WEBHOOK: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
-    with:
-      failure-status: ${{ contains(needs.*.result, 'failure') }}
-      cancelled-status: ${{ contains(needs.*.result, 'cancelled') }}
-      is-test: 'true'


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
- test notification
- test notification
