### PR TITLE
fix cicd

### DIFF
--- a/.github/workflows/player_cicd.yaml
+++ b/.github/workflows/player_cicd.yaml
@@ -58,14 +58,7 @@ on:
         default: 'false'
 
 jobs:
-  running-tests:
-    uses: ./.github/workflows/player_tests.yaml
-    with:
-      yarn-run-to-execute: ${{ inputs.tests-yarn-run-to-execute }}
-      run-on-ubuntu: ${{ inputs.run-on-ubuntu }}
-      run-on-macos: ${{ inputs.run-on-macos }}
   accept-prod:
-    needs: running-tests
     if: ${{ inputs.env == 'prod' }}
     runs-on: ubuntu-latest
     name: Accept Prod
@@ -74,8 +67,16 @@ jobs:
       - name: accept workflow on prod
         run: |
           echo "accepted"
-  upload-packages-to-npm:
+  running-tests:
+    if: (always()) && (needs.accept-prod.result == 'success' || needs.accept-prod.result == 'skipped')
     needs: accept-prod
+    uses: ./.github/workflows/player_tests.yaml
+    with:
+      yarn-run-to-execute: ${{ inputs.tests-yarn-run-to-execute }}
+      run-on-ubuntu: ${{ inputs.run-on-ubuntu }}
+      run-on-macos: ${{ inputs.run-on-macos }}
+  upload-packages-to-npm:
+    needs: running-tests
     uses: ./.github/workflows/player_upload_to_npm.yaml
     secrets:
       PLAYER_NPM_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
- test notification
- test notification
- test notification
- add secret
- add secret
- fix notifica
- fix notition
- added flag for prod env
- test prod
- test prod
- add token for push tag in github
- add token create release
- fix conventional-github-releaser
- change the order of the cicd
- add env to player_upload_to_s3 workflow
- fix example
- fix cicd
