### PR TITLE
fix cicd

### DIFF
--- a/.github/workflows/player_cicd.yaml
+++ b/.github/workflows/player_cicd.yaml
@@ -76,6 +76,7 @@ jobs:
       run-on-ubuntu: ${{ inputs.run-on-ubuntu }}
       run-on-macos: ${{ inputs.run-on-macos }}
   upload-packages-to-npm:
+    if: (always() && needs.running-tests.result == 'success')
     needs: running-tests
     uses: ./.github/workflows/player_upload_to_npm.yaml
     secrets:
@@ -85,6 +86,7 @@ jobs:
       env: ${{ inputs.env }}
       yarn-upgrade-list: ${{ inputs.yarn-upgrade-list }}
   upload-to-s3:
+    if: (always() && needs.upload-packages-to-npm.result == 'success')
     needs: upload-packages-to-npm
     uses: ./.github/workflows/player_upload_to_s3.yaml
     secrets:
@@ -97,6 +99,7 @@ jobs:
       version: ${{ needs.upload-packages-to-npm.outputs.version }}
       full-npm-name: ${{ needs.upload-packages-to-npm.outputs.full-npm-name }}
   update-schema:
+    if: (always() && needs.upload-to-s3.result == 'success')
     needs: [upload-to-s3, upload-packages-to-npm]
     uses: ./.github/workflows/player_update_schema.yaml
     secrets:
@@ -110,7 +113,7 @@ jobs:
       name: ${{ needs.upload-packages-to-npm.outputs.name }}
       version: ${{ needs.upload-packages-to-npm.outputs.version }}
   build-uiconf:
-    if: ${{ inputs.stage == 'canary' }}
+    if: (always() && needs.update-schema.result == 'success' && ${{ inputs.stage == 'canary' }})
     needs: [update-schema, upload-to-s3, upload-packages-to-npm]
     uses: ./.github/workflows/player_build_uiconf.yaml
     secrets:
@@ -121,7 +124,7 @@ jobs:
       stage: ${{ inputs.stage }}
       schema-type: ${{ inputs.schema-type }}
   deploy-uiconf:
-    if: ${{ inputs.stage == 'canary' }}
+    if: (always() && needs.build-uiconf.result == 'success' && ${{ inputs.stage == 'canary' }})
     needs: [ build-uiconf, update-schema, upload-to-s3, upload-packages-to-npm ]
     uses: ./.github/workflows/player_deploy_uiconf.yaml
     secrets:


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
- test notification
- test notification
- test notification
- add secret
- add secret
- fix notifica
- fix notition
- added flag for prod env
- test prod
- test prod
- add token for push tag in github
- add token create release
- fix conventional-github-releaser
- change the order of the cicd
- add env to player_upload_to_s3 workflow
- fix example
- fix cicd
- fix cicd
