### PR TITLE
add ls before yarn publish and fix NODE_OPTIONS env

### DIFF
--- a/.github/examples/run_canary_full_flow.yaml
+++ b/.github/examples/run_canary_full_flow.yaml
@@ -21,7 +21,8 @@ jobs:
       PLAYER_MSTEAMS_WEBHOOK: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
       PLAYER_GITHUB_BOT_TOKEN: ${{ secrets.PLAYER_GITHUB_BOT_TOKEN }}
     with:
-      type: "plugin/dependency"
+      type: "plugin"
+      #type: "dependency"
       stage: "canary"
       schema-type: "playerV3Versions"
       tests-yarn-run-to-execute: 'eslint flow test'

--- a/.github/workflows/player_tests.yaml
+++ b/.github/workflows/player_tests.yaml
@@ -81,10 +81,8 @@ jobs:
       - name: Yarn run ${{ inputs.yarn-run-to-execute }}
         run: |
           if [ "${{ inputs.enabled-openssl-legacy-provider }}" = "true" ]; then
-            echo "NODE_OPTIONS=openssl-legacy-provider" >> $GITHUB_ENV
+            echo "NODE_OPTIONS=--openssl-legacy-provider" >> $GITHUB_ENV
           fi
           for command in ${{ inputs.yarn-run-to-execute }}; do
             yarn run $command
           done
-        env:
-          NODE_OPTIONS: "--openssl-legacy-provider"

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Yarn run build
         run: |
           if [ "${{ inputs.enabled-openssl-legacy-provider }}" = "true" ]; then
-            echo "NODE_OPTIONS=openssl-legacy-provider" >> $GITHUB_ENV
+            echo "NODE_OPTIONS=--openssl-legacy-provider" >> $GITHUB_ENV
           fi
           yarn run build
           ls -la

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -101,10 +101,12 @@ jobs:
             echo "NODE_OPTIONS=openssl-legacy-provider" >> $GITHUB_ENV
           fi
           yarn run build
+          ls -la
 
       - name: Yarn publish
         run: |
           if [ "${{ inputs.env }}" = "prod" ]; then
+            ls -la
             yarn publish
           else
             yarn publish --tag canary


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
- test notification
- test notification
- test notification
- add secret
- add secret
- fix notifica
- fix notition
- added flag for prod env
- test prod
- test prod
- add token for push tag in github
- add token create release
- fix conventional-github-releaser
- change the order of the cicd
- add env to player_upload_to_s3 workflow
- fix example
- fix cicd
- fix cicd
- fix aws cred
- commited steps in notification and fix conditions
- fix notification
- fix notification
- fix notification on dispatch workflow and align the comments
- fix notification needs in promotion job
- fix notification needs in promotion job
- fix file-name var
- fix the cat of file in promote schema
- chage master to tag in the examples
- fixed name package recognize in upload to npm pipeline
- add new type named dependency and fix the player and add new feature for pass player type as a var
- fix file name
- add capability to unset the NODE_OPTIONS
- add capability to unset the NODE_OPTIONS
- add capability to unset the NODE_OPTIONS
- add ls before yarn publish
- add ls before yarn publish
