### PR TITLE
fix NODE_OPTION issue and cancelled notification on secces

### DIFF
--- a/.github/workflows/notification.yaml
+++ b/.github/workflows/notification.yaml
@@ -69,7 +69,7 @@ jobs:
           echo "inputs=${inputs}" >> $GITHUB_OUTPUT
       - name: Microsoft Teams Notification pull_request
         uses: skitionek/notify-microsoft-teams@v1.0.4
-        if: (always()) && (github.event_name == 'pull_request')
+        if: (always() && github.event_name == 'pull_request' && steps.status.outputs.status != 'success')
         with:
           webhook_url: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
           raw: >-
@@ -104,7 +104,7 @@ jobs:
             }
       - name: Microsoft Teams Notification push
         uses: skitionek/notify-microsoft-teams@v1.0.4
-        if: (always()) && (github.event_name == 'push')
+        if: (always() && github.event_name == 'push' && steps.status.outputs.status != 'success')
         with:
           webhook_url: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
           raw: >-
@@ -137,7 +137,7 @@ jobs:
             }
       - name: Microsoft Teams Notification workflow_dispatch
         uses: skitionek/notify-microsoft-teams@v1.0.4
-        if: (always()) && (github.event_name == 'workflow_dispatch')
+        if: (always() && github.event_name == 'workflow_dispatch' && steps.status.outputs.status != 'success')
         with:
           webhook_url: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
           raw: >-
@@ -173,7 +173,7 @@ jobs:
             }
       - name: Microsoft Teams Notification Tests
         uses: skitionek/notify-microsoft-teams@v1.0.4
-        if: (always()) && (inputs.is-test == 'true')
+        if: (always() && inputs.is-test == 'true' && steps.status.outputs.status != 'success')
         with:
           webhook_url: ${{ secrets.PLAYER_MSTEAMS_WEBHOOK }}
           raw: >-

--- a/.github/workflows/player_cicd.yaml
+++ b/.github/workflows/player_cicd.yaml
@@ -94,6 +94,7 @@ jobs:
     with:
       env: ${{ inputs.env }}
       yarn-upgrade-list: ${{ inputs.yarn-upgrade-list }}
+      enabled-openssl-legacy-provider: ${{ inputs.enabled-openssl-legacy-provider }}
   upload-to-s3:
     if: (always() && needs.upload-packages-to-npm.result == 'success' && inputs.type != 'dependency')
     needs: upload-packages-to-npm

--- a/.github/workflows/player_cicd.yaml
+++ b/.github/workflows/player_cicd.yaml
@@ -60,6 +60,11 @@ on:
         description: "player type - example 'ovp tv'"
         required: false
         type: string
+      enabled-openssl-legacy-provider:
+        description: "enable the NODE_OPTIONS --openssl-legacy-provider - example: 'ture/false'"
+        required: false
+        type: string
+        default: 'true'
 
 jobs:
   accept-prod:

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -17,6 +17,11 @@ on:
         description: "env - example: 'qa/prod'"
         required: false
         type: string
+      enabled-openssl-legacy-provider:
+        description: "enable the NODE_OPTIONS --openssl-legacy-provider - example: 'ture/false'"
+        required: false
+        type: string
+        default: 'true'
     outputs:
       name:
         description: "name"
@@ -93,9 +98,14 @@ jobs:
           rm CHANGELOG.mdE
 
       - name: Yarn run build
+        if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}
         run: yarn run build
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
+
+      - name: Yarn run build
+        if: ${{ inputs.enabled-openssl-legacy-provider != 'true' }}
+        run: yarn run build
 
       - name: Yarn publish
         run: |


### PR DESCRIPTION
- run tests and create canary version and update uiconf
- add retry to node setup
- fix for loop in deploy uiconf
- fix json conf to be one line
- fix json in uiconf deploy
- add examples for using worklows
- fix version in uiconf
- add spaces on new tags for uiconf
- align secrets
- changed the default rusable workflow to pull from master
- add nvd1 for deploy uiconf
- add conditions in tests
- add conditions in tests
- add set matrix in tests
- add set matrix in tests
- add set matrix in tests
- add notification in tests
- change run_prod to workflow_dispatch and add environment
- add another notification type for test in pull request
- test notification
- test notification
- test notification
- add secret
- add secret
- fix notifica
- fix notition
- added flag for prod env
- test prod
- test prod
- add token for push tag in github
- add token create release
- fix conventional-github-releaser
- change the order of the cicd
- add env to player_upload_to_s3 workflow
- fix example
- fix cicd
- fix cicd
- fix aws cred
- commited steps in notification and fix conditions
- fix notification
- fix notification
- fix notification on dispatch workflow and align the comments
- fix notification needs in promotion job
- fix notification needs in promotion job
- fix file-name var
- fix the cat of file in promote schema
- chage master to tag in the examples
- fixed name package recognize in upload to npm pipeline
- add new type named dependency and fix the player and add new feature for pass player type as a var
- fix file name
- add capability to unset the NODE_OPTIONS
- add capability to unset the NODE_OPTIONS
- add capability to unset the NODE_OPTIONS
- add ls before yarn publish
- add ls before yarn publish
- fix NODE_OPTIONS
- fix NODE_OPTIONS
- fix NODE_OPTIONS
- fix NODE_OPTIONS
- fixed the yarn build
- fixed the yarn build
- cancelled notification on secces
