### PR TITLE
VCP-19315: Update player deployment workflow to track previous version for latest stage

### DIFF
--- a/.github/workflows/player_deploy_kconf.yaml
+++ b/.github/workflows/player_deploy_kconf.yaml
@@ -211,7 +211,7 @@ jobs:
                 exit 1
               fi
               if [[ ${STAGE} == "latest" ]]; then
-                PLAYKIT_PREVIOUS_VERSION_PATH="${PLAYKIT_VERSION_SCHEMA_BASE_NAME}.${SCHEMA_TYPE}.${STAGE}-prev.${NAME}"
+                PLAYKIT_PREVIOUS_VERSION_PATH="${PLAYKIT_VERSION_SCHEMA_BASE_NAME}.${SCHEMA_TYPE}.${STAGE}_prev.${NAME}"
                 yq "${PLAYKIT_PREVIOUS_VERSION_PATH} = \"${CURRENT_VERSION}\"" "${ENV}" -i
               fi
               echo "Updated: ${NAME} = \"${VERSION}\""

--- a/.github/workflows/player_deploy_kconf.yaml
+++ b/.github/workflows/player_deploy_kconf.yaml
@@ -200,27 +200,31 @@ jobs:
               VERSION=$(echo "${PARAMS}" | jq -r ".\"${PLAYKIT}\"")
               PLAYKIT_VERSION_PATH="${PLAYKIT_VERSION_SCHEMA_BASE_NAME}.${SCHEMA_TYPE}.${STAGE}.${NAME}"
               CURRENT_VERSION=$(yq "${PLAYKIT_VERSION_PATH}" "${ENV}" -r)
-          
+
               if [[ ${VERSION} == "${CURRENT_VERSION}" ]]; then
                 continue
               fi
-          
+
               yq "${PLAYKIT_VERSION_PATH} = \"${VERSION}\"" "${ENV}" -i
               if [[ $? -ne 0 ]]; then
                 echo "Failed to update ${ENV} with ${PLAYKIT_VERSION_PATH} = ${VERSION}"
                 exit 1
               fi
+              if [[ ${STAGE} == "latest" ]]; then
+                PLAYKIT_PREVIOUS_VERSION_PATH="${PLAYKIT_VERSION_SCHEMA_BASE_NAME}.${SCHEMA_TYPE}.${STAGE}-prev.${NAME}"
+                yq "${PLAYKIT_PREVIOUS_VERSION_PATH} = \"${CURRENT_VERSION}\"" "${ENV}" -i
+              fi
               echo "Updated: ${NAME} = \"${VERSION}\""
             done
 
             PRODUCT_VERSION_PATH="${PRODUCT_VERSION_YAML_BASE_NAME}.${SCHEMA_TYPE}.${STAGE}"
-          
+
             yq "${PRODUCT_VERSION_PATH} = \"${PRODUCT_VERSION}\"" "${ENV}" -i
             if [[ $? -ne 0 ]]; then
               echo "Failed to update ${ENV} with ${PRODUCT_VERSION_PATH} = ${PRODUCT_VERSION}"
               exit 1
             fi
-          
+
             NEW_PRODUCT_VERSION=$(yq "${PRODUCT_VERSION_PATH}" "${ENV}" -r)
             echo "Successfully deployed new product version: ${NEW_PRODUCT_VERSION}"
           done


### PR DESCRIPTION
Enhance the deployment workflow to store the previous version of the player when updating to the latest stage. This change ensures better version tracking during deployments.