### PR TITLE
chore: update player_upload_to_npm.yaml

### DIFF
--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -199,22 +199,22 @@ jobs:
           yarn run build
           ls -la dist/
 
-      - name: Npm publish
-        run: |
-          npm set registry "https://registry.npmjs.org"
-          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
-          if [ "${{ inputs.env }}" = "prod" ]; then
-            npm publish .
-          elif [ "${{ inputs.stage }}" = "patch" ]; then
-            npm publish . --tag patch
-          else
-            npm publish . --tag canary
-          fi
-          rm -rf .npmrc
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
+      # - name: Npm publish
+      #   run: |
+      #     npm set registry "https://registry.npmjs.org"
+      #     echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
+      #     if [ "${{ inputs.env }}" = "prod" ]; then
+      #       npm publish .
+      #     elif [ "${{ inputs.stage }}" = "patch" ]; then
+      #       npm publish . --tag patch
+      #     else
+      #       npm publish . --tag canary
+      #     fi
+      #     rm -rf .npmrc
+      #   env:
+      #     NPM_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
+      #     NPM_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
+      #     NODE_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
 
       - name: Yarn run pushTaggedRelease and create github release
         if: ${{ inputs.env == 'prod' }}

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -117,22 +117,6 @@ jobs:
               yarn add $package --exact
             done
           fi
-
-      # - name: Create temporary .npmrc
-      #   run: |
-      #     echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
-      #     echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
-      # - name: Preinstall
-      #   run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
-      #   env:
-      #     GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Remove temporary .npmrc
-      #   run: rm -f .npmrc
-      # - name: Disable preinstall
-      #   working-directory: ${{ github.workspace }}
-      #   run: |
-      #     sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
-      #     rm package.json.bak
       
       - name: Yarn install
         run: yarn install
@@ -141,12 +125,6 @@ jobs:
 
       - name: Remove temporary .npmrc
         run: rm -f .npmrc 
-
-      # - name: Enable preinstall
-      #   working-directory: ${{ github.workspace }}
-      #   run: |
-      #     sed -i.bak 's/"disabled-preinstall":/"preinstall":/' package.json
-      #     rm package.json.bak
 
       - name: Yarn run release with NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -153,6 +153,7 @@ jobs:
           fi
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Yarn run release without NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider != 'true' }}
@@ -164,6 +165,8 @@ jobs:
           else
             yarn run release --prerelease canary --skip.commit=true --skip.tag=true
           fi
+        env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update version in package.json file
         run: |

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -118,28 +118,26 @@ jobs:
             done
           fi
 
-      - name: Create temporary .npmrc
-        run: |
-          echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
-          echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
+      # - name: Create temporary .npmrc
+      #   run: |
+      #     echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
+      #     echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
       # - name: Preinstall
       #   run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
-
+      #   env:
+      #     GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # - name: Remove temporary .npmrc
       #   run: rm -f .npmrc
+      # - name: Disable preinstall
+      #   working-directory: ${{ github.workspace }}
+      #   run: |
+      #     sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
+      #     rm package.json.bak
       
-      - name: Yarn install
-        run: yarn install
-        env:
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Remove temporary .npmrc
-        run: rm -f .npmrc
-
-      - name: Recreate original .npmrc
-        run: |
-          echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
-          echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
+      # - name: Yarn install
+      #   run: yarn install
+      #   env:
+      #     GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Yarn run release with NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}
@@ -167,6 +165,12 @@ jobs:
           fi
         env:
           GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Disable preinstall
+        working-directory: ${{ github.workspace }}
+        run: |
+          sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
+          rm package.json.bak
 
       - name: Update version in package.json file
         run: |
@@ -198,6 +202,8 @@ jobs:
         run: |
           yarn run build
           ls -la dist/
+
+      # TODO revert package.json scripts ???
 
       # - name: Npm publish
       #   run: |

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -122,20 +122,24 @@ jobs:
         run: |
           echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
-      - name: Preinstall
-        run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
-        env:
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove temporary .npmrc
-        run: rm -f .npmrc
-      - name: Disable preinstall
-        working-directory: ${{ github.workspace }}
-        run: |
-          sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
-          rm package.json.bak
+      # - name: Preinstall
+      #   run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
+
+      # - name: Remove temporary .npmrc
+      #   run: rm -f .npmrc
       
       - name: Yarn install
         run: yarn install
+        env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove temporary .npmrc
+        run: rm -f .npmrc
+
+      - name: Recreate original .npmrc
+        run: |
+          echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
 
       - name: Yarn run release with NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -118,26 +118,30 @@ jobs:
             done
           fi
 
-      # - name: Create temporary .npmrc
-      #   run: |
-      #     echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
-      #     echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
-      # - name: Preinstall
-      #   run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
-      #   env:
-      #     GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Remove temporary .npmrc
-      #   run: rm -f .npmrc
-      # - name: Disable preinstall
-      #   working-directory: ${{ github.workspace }}
-      #   run: |
-      #     sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
-      #     rm package.json.bak
+      - name: Create temporary .npmrc
+        run: |
+          echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
+      - name: Preinstall
+        run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
+        env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove temporary .npmrc
+        run: rm -f .npmrc
+      - name: Disable preinstall
+        working-directory: ${{ github.workspace }}
+        run: |
+          sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
+          rm package.json.bak
       
       - name: Yarn install
         run: yarn install
-        env:
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable preinstall
+        working-directory: ${{ github.workspace }}
+        run: |
+          sed -i.bak 's/"disabled-preinstall":/"preinstall":/' package.json
+          rm package.json.bak
 
       - name: Yarn run release with NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}
@@ -151,7 +155,6 @@ jobs:
           fi
         env:
           NODE_OPTIONS: "--openssl-legacy-provider"
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Yarn run release without NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider != 'true' }}
@@ -163,14 +166,6 @@ jobs:
           else
             yarn run release --prerelease canary --skip.commit=true --skip.tag=true
           fi
-        env:
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Disable preinstall
-        working-directory: ${{ github.workspace }}
-        run: |
-          sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
-          rm package.json.bak
 
       - name: Update version in package.json file
         run: |
@@ -203,24 +198,22 @@ jobs:
           yarn run build
           ls -la dist/
 
-      # TODO revert package.json scripts ???
-
-      # - name: Npm publish
-      #   run: |
-      #     npm set registry "https://registry.npmjs.org"
-      #     echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
-      #     if [ "${{ inputs.env }}" = "prod" ]; then
-      #       npm publish .
-      #     elif [ "${{ inputs.stage }}" = "patch" ]; then
-      #       npm publish . --tag patch
-      #     else
-      #       npm publish . --tag canary
-      #     fi
-      #     rm -rf .npmrc
-      #   env:
-      #     NPM_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
-      #     NODE_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
+      - name: Npm publish
+        run: |
+          npm set registry "https://registry.npmjs.org"
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" > .npmrc
+          if [ "${{ inputs.env }}" = "prod" ]; then
+            npm publish .
+          elif [ "${{ inputs.stage }}" = "patch" ]; then
+            npm publish . --tag patch
+          else
+            npm publish . --tag canary
+          fi
+          rm -rf .npmrc
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PLAYER_NPM_TOKEN }}
 
       - name: Yarn run pushTaggedRelease and create github release
         if: ${{ inputs.env == 'prod' }}

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -134,10 +134,10 @@ jobs:
       #     sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
       #     rm package.json.bak
       
-      # - name: Yarn install
-      #   run: yarn install
-      #   env:
-      #     GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Yarn install
+        run: yarn install
+        env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Yarn run release with NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -139,11 +139,14 @@ jobs:
         env:
           GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Enable preinstall
-        working-directory: ${{ github.workspace }}
-        run: |
-          sed -i.bak 's/"disabled-preinstall":/"preinstall":/' package.json
-          rm package.json.bak
+      - name: Remove temporary .npmrc
+        run: rm -f .npmrc 
+
+      # - name: Enable preinstall
+      #   working-directory: ${{ github.workspace }}
+      #   run: |
+      #     sed -i.bak 's/"disabled-preinstall":/"preinstall":/' package.json
+      #     rm package.json.bak
 
       - name: Yarn run release with NODE_OPTIONS
         if: ${{ inputs.enabled-openssl-legacy-provider == 'true' }}

--- a/.github/workflows/player_upload_to_npm.yaml
+++ b/.github/workflows/player_upload_to_npm.yaml
@@ -118,24 +118,26 @@ jobs:
             done
           fi
 
-      - name: Create temporary .npmrc
-        run: |
-          echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
-          echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
-      - name: Preinstall
-        run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
-        env:
-          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove temporary .npmrc
-        run: rm -f .npmrc
-      - name: Disable preinstall
-        working-directory: ${{ github.workspace }}
-        run: |
-          sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
-          rm package.json.bak
+      # - name: Create temporary .npmrc
+      #   run: |
+      #     echo "@kaltura:registry=https://npm.pkg.github.com" > .npmrc
+      #     echo "//npm.pkg.github.com/:_authToken=\${GIT_TOKEN}" >> .npmrc
+      # - name: Preinstall
+      #   run: npx --yes --prefer-online --registry=https://npm.pkg.github.com --package @kaltura/kaltura-tools@latest kaltura-tools check --root=.
+      #   env:
+      #     GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Remove temporary .npmrc
+      #   run: rm -f .npmrc
+      # - name: Disable preinstall
+      #   working-directory: ${{ github.workspace }}
+      #   run: |
+      #     sed -i.bak 's/"preinstall":/"disabled-preinstall":/' package.json
+      #     rm package.json.bak
       
       - name: Yarn install
         run: yarn install
+        env:
+          GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable preinstall
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
- do not rename preinstall script to disabled-preinstall so that it won't be committed by prod action
- run preinstall through yarn install - pass git token as env variable to yarn install so that preinstall won't fail
- delete .npmrc after yarn install because it fails all the following "yarn X" scripts (probably because it contains an unset variable)
- deleting the .npmrc file is not commited by the prod script